### PR TITLE
Wrapper script gollvm-wrap.py for combining gollvm with gccgo.

### DIFF
--- a/tools/gollvm-wrap.py
+++ b/tools/gollvm-wrap.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+"""Wrapper to selectively run gollvm instead of gccgo.
+
+This is a shim script that intercepts invocations of 'gccgo' and then
+in turn invokes either the real gccgo driver or a copy of gollvm
+instead, depending on the arguments and on environment variables.
+
+When performing a Go build with gccgo, the Go command will typically
+invoke gccgo once for each compilation step, which might look like
+
+  gccgo -I ... -o objfile.o -g <options> file.go file2.go ... fileN.go
+
+and then a final invocation will be made at the link step, e.g.
+
+  gccgo -L ... somearchive.a ... -o binary
+
+The goal of this shim is to convert invocations of the first form to
+llvm-goparse invocations, and to ignore invocations of the second form
+and just pass them on to gccgo.
+
+We also tack on a set of additional "-L" options to the llvm-goparse
+invocation so that it can find the go runtime libraries, and intercept
+the "-o" option so that we can run the asembler afterwards.
+
+To use this script, you will need a copy of GCCGO, e.g. the directory
+produced by running "make all && make install" in a GCCGO build tree.
+From within the gccgo install dir, run
+
+   gollvm-wrap.py --install
+
+This will modify the install directory to insert the wrapper into the
+compilation path.
+
+"""
+
+import getopt
+import os
+import re
+import subprocess
+import sys
+
+import script_utils as u
+
+# Echo command before executing
+flag_echo = True
+
+# Dry run mode
+flag_dryrun = False
+
+# gccgo only mode
+flag_nollvm = False
+
+# trace llvm-goparse invocations
+flag_trace_llinvoc = False
+
+
+def docmd(cmd):
+  """Execute a command."""
+  if flag_echo:
+    sys.stderr.write("executing: " + cmd + "\n")
+  if flag_dryrun:
+    return
+  u.docmd(cmd)
+
+
+def form_golibargs(driver):
+  """Form correct go library args."""
+  ddir = os.path.dirname(driver)
+  bdir = os.path.dirname(ddir)
+  cmd = "find %s/lib64 -name runtime.gox -print" % bdir
+  lines = u.docmdlines(cmd)
+  if not lines:
+    u.error("no output from %s -- bad gccgo install dir?" % cmd)
+  line = lines[0]
+  rdir = os.path.dirname(line)
+  u.verbose(1, "libdir is %s" % rdir)
+  return ["-L", rdir]
+
+
+def perform():
+  """Main driver routine."""
+
+  u.verbose(1, "argv: %s" % " ".join(sys.argv))
+
+  # Perform a walk of the command line arguments looking for Go files.
+  reg = re.compile(r"^\S+\.go$")
+  foundgo = False
+  for clarg in sys.argv[1:]:
+    m = reg.match(clarg)
+    if m:
+      foundgo = True
+      break
+
+  if not foundgo or flag_nollvm:
+    # No go files. Invoke real gccgo.
+    bd = os.path.dirname(sys.argv[0])
+    driver = "%s/gccgo.real" % bd
+    u.verbose(1, "driver path is %s" % driver)
+    args = [sys.argv[0]] + sys.argv[1:]
+    u.verbose(1, "args: '%s'" % " ".join(args))
+    if not os.path.exists(driver):
+      u.warning("internal error: %s does not exist" % driver)
+      u.warning("[most likely this script was not installed correctly]")
+      usage()
+    os.execv(driver, args)
+    u.error("exec failed: %s" % driver)
+
+  # Create a set of massaged args.
+  nargs = []
+  skipc = 0
+  outfile = None
+  asmfile = None
+  for ii in range(1, len(sys.argv)):
+    clarg = sys.argv[ii]
+    if skipc != 0:
+      skipc -= 1
+      continue
+    if clarg == "-o":
+      skipc = 1
+      outfile = sys.argv[ii+1]
+      asmfile = "%s.s" % outfile
+      nargs.append("-o")
+      nargs.append(asmfile)
+      continue
+    nargs.append(clarg)
+
+  if not asmfile or not outfile:
+    u.error("fatal error: unable to find -o "
+            "option in clargs: %s" % " ".join(sys.argv))
+  golibargs = form_golibargs(sys.argv[0])
+  nargs += golibargs
+  u.verbose(1, "revised args: %s" % " ".join(nargs))
+
+  # Invoke gollvm.
+  driver = "llvm-goparse"
+  u.verbose(1, "driver path is %s" % driver)
+  nargs = ["llvm-goparse"] + nargs
+  if flag_trace_llinvoc:
+    u.verbose(0, "+ %s" % " ".join(nargs))
+  rc = subprocess.call(nargs)
+  if rc != 0:
+    u.verbose(1, "return code %d from %s" % (rc, " ".join(nargs)))
+    return 1
+
+  # Invoke the assembler
+  ascmd = "as %s -o %s" % (asmfile, outfile)
+  u.verbose(1, "asm command is: %s" % ascmd)
+  rc = u.docmdnf(ascmd)
+  if rc != 0:
+    u.verbose(1, "return code %d from %s" % (rc, ascmd))
+    return 1
+
+  return 0
+
+
+def install_shim(scriptpath):
+  """Install shim into gccgo install dir."""
+
+  # Make sure we're in the right place (gccgo install dir)
+  if not os.path.exists("bin"):
+    usage("expected to find bin subdir")
+  if not os.path.exists("lib64/libgo.so"):
+    usage("expected to find lib64/libgo.so")
+  if not os.path.exists("bin/gccgo"):
+    usage("expected to find bin/gccgo")
+
+  # Check to see if installed already
+  if os.path.exists("bin/gccgo.real") and os.path.exists("bin/gollvm-wrap.py"):
+    u.error("wrapper appears to be installed already in this dir")
+
+  # Move aside the real gccgo binary
+  docmd("mv bin/gccgo bin/gccgo.real")
+
+  # Emit a script into gccgo
+  if flag_dryrun:
+    sys.stderr.write("<emit script into bin/gccgo>\n")
+  else:
+    try:
+      with open("./bin/gccgo", "w") as wf:
+        here = os.getcwd()
+        wf.write("#!/bin/sh\n")
+        wf.write("P=%s/bin/gollvm-wrap.py\n" % here)
+        wf.write("exec python ${P} $*\n")
+    except IOError:
+      u.error("open/write failed for bin/gccgo wrapper")
+  docmd("chmod 0755 bin/gccgo")
+
+  # Copy script
+  docmd("cp %s bin" % scriptpath)
+  sdir = os.path.dirname(scriptpath)
+  docmd("cp %s/script_utils.py bin" % sdir)
+
+  # Success
+  u.verbose(0, "wrapper installed successfully")
+
+  # Done
+  return 0
+
+
+def usage(msgarg):
+  """Print usage and exit."""
+  if msgarg:
+    sys.stderr.write("error: %s\n" % msgarg)
+  print """\
+    usage:  %s <gccgo args>
+
+    Options (via command line)
+    --install   installs wrapper into gccgo directory
+
+    Options (via GOLLVM_WRAP_OPTIONS):
+    -t          trace llvm-goparse executions
+    -d          increase debug msg verbosity level
+    -e          show commands being invoked
+    -D          dry run (echo cmds but do not execute)
+    -G          pure gccgo compile (no llvm-goparse invocations)
+
+    """ % os.path.basename(sys.argv[0])
+  sys.exit(1)
+
+
+def parse_env_options():
+  """Option parsing from env var."""
+  global flag_echo, flag_dryrun, flag_nollvm, flag_trace_llinvoc
+
+  optstr = os.getenv("GOLLVM_WRAP_OPTIONS")
+  if not optstr:
+    return
+  args = optstr.split()
+
+  try:
+    optlist, _ = getopt.getopt(args, "detDG")
+  except getopt.GetoptError as err:
+    # unrecognized option
+    usage(str(err))
+
+  for opt, _ in optlist:
+    if opt == "-d":
+      u.increment_verbosity()
+    elif opt == "-e":
+      flag_echo = True
+    elif opt == "-t":
+      flag_trace_llinvoc = True
+    elif opt == "-D":
+      flag_dryrun = True
+    elif opt == "-G":
+      flag_nollvm = True
+  u.verbose(1, "env var options parsing complete")
+
+
+# Setup
+u.setdeflanglocale()
+parse_env_options()
+
+# Either --install mode or regular mode
+if len(sys.argv) == 2 and sys.argv[1] == "--install":
+  prc = install_shim(sys.argv[0])
+else:
+  prc = perform()
+sys.exit(prc)

--- a/tools/script_utils.py
+++ b/tools/script_utils.py
@@ -1,0 +1,302 @@
+#!/usr/bin/python
+"""Utility functions for scripts in my bin diretory.
+
+This module contains common utilities such as wrappers for
+error/warning reporting, executing shell commands in a controlled way,
+etc. These functions are shared by a number of helper scripts.
+
+"""
+
+import locale
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+
+# Debugging verbosity level (0 -> no output)
+flag_debug = 0
+
+# Unit testing mode. If set to 1, throw exception instead of calling exit()
+flag_unittest = 0
+
+hrszre = re.compile(r"^([\d\.]+)(\S)$")
+factors = {"K": 1024.0, "M": 1048576.0, "G": 1073741824.0}
+
+
+def verbose(level, msg):
+  """Print debug trace output of verbosity level is >= value in 'level'."""
+  if level <= flag_debug:
+    sys.stderr.write(msg + "\n")
+
+
+def verbosity_level():
+  """Return debug trace level."""
+  return flag_debug
+
+
+def increment_verbosity():
+  """Increment debug trace level by 1."""
+  global flag_debug
+  flag_debug += 1
+
+
+def decrement_verbosity():
+  """Lower debug trace level by 1."""
+  global flag_debug
+  flag_debug -= 1
+
+
+def unit_test_enable():
+  """Set unit testing mode."""
+  global flag_unittest
+  sys.stderr.write("+++ unit testing mode enabled +++\n")
+  flag_unittest = 1
+
+
+def warning(msg):
+  """Issue a warning to stderr."""
+  sys.stderr.write("warning: " + msg + "\n")
+
+
+def error(msg):
+  """Issue an error to stderr, then exit."""
+  errm = "error: " + msg + "\n"
+  sys.stderr.write(errm)
+  if flag_unittest:
+    raise Exception(errm)
+  else:
+    exit(1)
+
+
+def docmd(cmd):
+  """Run a command via subprocess, issuing fatal error if cmd fails."""
+  args = shlex.split(cmd)
+  verbose(2, "+ docmd executing: %s" % cmd)
+  rc = subprocess.call(args)
+  if rc != 0:
+    error("command failed: %s" % cmd)
+
+
+# Similar to docmd, but return status after issuing failure message
+def docmdnf(cmd):
+  """Run a command via subprocess, returning exit status."""
+  args = shlex.split(cmd)
+  verbose(2, "+ docmd executing: %s" % cmd)
+  rc = subprocess.call(args)
+  return rc
+
+
+# Similar to docmd, but suppress output
+def doscmd(cmd, nf=None):
+  """Run a command via subprocess, suppressing output unless error."""
+  verbose(2, "+ doscmd executing: %s" % cmd)
+  args = shlex.split(cmd)
+  cmdtf = tempfile.NamedTemporaryFile(mode="w", delete=True)
+  rc = subprocess.call(args, stdout=cmdtf, stderr=cmdtf)
+  if rc != 0:
+    warning("error: command failed (rc=%d) cmd: %s" % (rc, cmd))
+    warning("output from failing command:")
+    subprocess.call(["cat", cmdtf.name])
+    if nf:
+      return None
+    error("")
+  cmdtf.close()
+  return True
+
+
+# invoke command, writing output to file
+def docmdout(cmd, outfile, nf=None):
+  """Run a command via subprocess, writing output to a file."""
+  verbose(2, "+ docmdout executing: %s > %s" % (cmd, outfile))
+  args = shlex.split(cmd)
+  with open(outfile, "w") as outfile:
+    rc = subprocess.call(args, stdout=outfile)
+    if rc != 0:
+      warning("error: command failed (rc=%d) cmd: %s" % (rc, cmd))
+      if nf:
+        return None
+      error("")
+  return True
+
+# invoke command, writing output to file
+def docmderrout(cmd, outfile, nf=None):
+  """Run a command via subprocess, writing output to a file."""
+  verbose(2, "+ docmdout executing: %s > %s" % (cmd, outfile))
+  args = shlex.split(cmd)
+  try:
+    with open(outfile, "w") as outfile:
+      rc = subprocess.call(args, stdout=outfile, stderr=outfile)
+      if rc != 0:
+        if nf:
+          sys.stderr.write("error: command failed (rc=%d) cmd: %s\n" % (rc, cmd))
+          return rc
+        else:
+          error("command failed (rc=%d) cmd: %s\n" % (rc, cmd))
+      return rc
+  except IOError:
+    error("unable to open %s for writing" % outfile)
+
+
+# invoke command, reading from one file and writing to another
+def docmdinout(cmd, infile, outfile):
+  """Run a command via subprocess with input and output file."""
+  verbose(2, "+ docmdinout executing: %s < %s > %s" % (cmd, infile, outfile))
+  args = shlex.split(cmd)
+  cmdtf = tempfile.NamedTemporaryFile(mode="w", delete=True)
+  with open(infile, "r") as inf:
+    with open(outfile, "w") as outf:
+      rc = subprocess.call(args, stdout=outf, stdin=inf, stderr=cmdtf)
+      if rc != 0:
+        warning("error: command failed (rc=%d) cmd: %s" % (rc, cmd))
+        warning("output from failing command:")
+        subprocess.call(["cat", cmdtf.name])
+        return 1
+  verbose(2, "+ finished: %s < %s > %s" % (cmd, infile, outfile))
+  return 0
+
+
+# invoke command, returning array of lines read from it
+def docmdlines(cmd, nf=None):
+  """Run a command via subprocess, returning output as an array of lines."""
+  verbose(2, "+ docmdlines executing: %s" % cmd)
+  args = shlex.split(cmd)
+  mypipe = subprocess.Popen(args, stdout=subprocess.PIPE)
+  encoding = locale.getdefaultlocale()[1]
+  pout, perr = mypipe.communicate()
+  if mypipe.returncode != 0:
+    if perr:
+      decoded_err = perr.decode(encoding)
+      warning(decoded_err)
+    if nf:
+      return None
+    error("command failed (rc=%d): cmd was %s" % (mypipe.returncode, args))
+  decoded = pout.decode(encoding)
+  lines = decoded.strip().split("\n")
+  return lines
+
+
+# invoke command, returning raw bytes from read
+def docmdbytes(cmd, nf=None):
+  """Run a command via subprocess, returning output as raw bytestring."""
+  args = shlex.split(cmd)
+  mypipe = subprocess.Popen(args, stdout=subprocess.PIPE)
+  pout, perr = mypipe.communicate()
+  if mypipe.returncode != 0:
+    encoding = locale.getdefaultlocale()[1]
+    if perr:
+      decoded_err = perr.decode(encoding)
+      warning(decoded_err)
+    if nf:
+      return None
+    error("command failed (rc=%d): cmd was %s" % (mypipe.returncode, args))
+  return pout
+
+
+# invoke a command with input coming from an echo'd string, e.g.
+# Ex: "echo 1+2 | perl"
+def docmdinstring(cmd, instring):
+  """Invoke a command with stdin coming from a specific string."""
+  verbose(2, "+ docmdinstring executing: echo %s | %s " % (cmd, instring))
+  args = shlex.split(cmd)
+  mypipe = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  encoding = locale.getdefaultlocale()[1]
+  pout, perr = mypipe.communicate(instring)
+  if mypipe.returncode != 0:
+    if perr:
+      decoded_err = perr.decode(encoding)
+      warning(decoded_err)
+    error("command failed (rc=%d): cmd was %s" % (mypipe.returncode, args))
+  decoded = pout.decode(encoding)
+  lines = decoded.strip().split("\n")
+  return lines
+
+
+# Execute a command with an alarm timeout.
+def docmdwithtimeout(cmd, timeout_duration):
+  """Run a command via subprocess, returning exit status or -1 if timeout."""
+
+  class TimeoutError(Exception):
+    pass
+
+  def handler(signum, frame):
+    raise TimeoutError()
+
+  # set the timeout handler
+  prevhandler = signal.signal(signal.SIGALRM, handler)
+  signal.alarm(timeout_duration)
+  try:
+    result = docmdnf(cmd)
+  except TimeoutError as exc:
+    verbose(1, "timeout triggered after %d seconds" % timeout_duration)
+    result = -1
+  finally:
+    signal.alarm(0)
+    signal.signal(signal.SIGALRM, prevhandler)
+  return result
+
+
+# perform default locale setup if needed
+def setdeflanglocale():
+  if "LANG" not in os.environ:
+    warning("no env setting for LANG -- using default values")
+    os.environ["LANG"] = "en_US.UTF-8"
+    os.environ["LANGUAGE"] = "en_US:"
+
+
+def determine_btrfs_ssdroot(here):
+  """Determine ssd root."""
+
+  path_components = here.split("/")
+  root = "/%s" % path_components[1]
+  verbose(2, "cwd=%s root=%s" % (here, root))
+
+  # Is this a BTRFS ssd to begin with?
+  outlines = docmdlines("stat -f --printf=%%T %s" % root)
+  if not outlines:
+    error("internal error-- could not determine FS type "
+          "for root dir %s" % root)
+  if outlines[0] != "btrfs":
+    error("current FS type is %s, not btrfs (can't proceed)" % outlines[0])
+  return root
+
+
+def hr_size_to_bytes(sz):
+  """Convert human readable size back to bytes."""
+  m = hrszre.match(sz)
+  if not m:
+    warning("unmatchable size expr %s" % sz)
+    return None
+  val = float(m.group(1))
+  facs = m.group(2)
+  if facs not in factors:
+    warning("unknown factor '%s' in size expr %s" % (facs, sz))
+    return None
+  fac = factors[facs]
+  nb = int(val * fac)
+  return nb
+
+
+def trim_perf_report_file(infile):
+  """Trim trailing spaces from lines in perf report."""
+  verbose(1, "trim: reading " + infile)
+  try:
+    f = open(infile, "r")
+  except IOError:
+    warning("unable to open file %s for reading" % infile)
+    return 1
+  lines = f.readlines()
+  f.close()
+  verbose(1, "trim: rewriting " + infile)
+  try:
+    ft = open(infile, "w")
+  except IOError:
+    warning("unable to open file %s for rewriting" % infile)
+    return 1
+  for line in lines:
+    sline = line.rstrip()
+    ft.write(sline + "\n")
+  ft.close()
+  return 0


### PR DESCRIPTION
This wrapper/shim allows you to do "go build" / "go run" invocations
where the compile step is performed by llvm-goparse and the remainder
of the build / link is done with gccgo.